### PR TITLE
#3 feat: init travis-ci tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 composer.lock
 vendor
-bin
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,31 +15,31 @@ matrix:
         - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel ^5.5 (LTS) vendors
     - php: 7.1
       env:
-        - COMPOSER_FLAGS="" # Cover laravel latest (LTS) vendors
+        - COMPOSER_FLAGS="" # Cover laravel latest vendors
     - php: 7.2
       env:
         - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel ^5.5 (LTS) vendors
     - php: 7.2
       env:
-        - COMPOSER_FLAGS="" # Cover laravel latest (LTS) vendors
+        - COMPOSER_FLAGS="" # Cover laravel latest vendors
     - php: 7.3
       env:
         - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel ^5.5 (LTS) vendors
     - php: 7.3
       env:
-        - COMPOSER_FLAGS="" # Cover laravel latest (LTS) vendors
+        - COMPOSER_FLAGS="" # Cover laravel latest vendors
     - php: 7.4
       env:
         - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel ^5.5 (LTS) vendors
     - php: 7.4
       env:
-        - COMPOSER_FLAGS="" # Cover laravel latest (LTS) vendors
+        - COMPOSER_FLAGS="" # Cover laravel latest vendors
     - php: nightly
       env:
         - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel ^5.5 (LTS) vendors
     - php: nightly
       env:
-        - COMPOSER_FLAGS="" # Cover laravel latest (LTS) vendors
+        - COMPOSER_FLAGS="" # Cover laravel latest vendors
   allow_failures:
     - php: 7.4
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,34 +12,34 @@ matrix:
   include:
     - php: 7.1
       env:
-        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel ^5.5 (LTS) vendors
     - php: 7.1
       env:
-        - COMPOSER_FLAGS="" # Cover laravel 7.0.x (LTS) vendors
+        - COMPOSER_FLAGS="" # Cover laravel latest (LTS) vendors
     - php: 7.2
       env:
-        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel ^5.5 (LTS) vendors
     - php: 7.2
       env:
-        - COMPOSER_FLAGS="" # Cover laravel 7.0.x (LTS) vendors
+        - COMPOSER_FLAGS="" # Cover laravel latest (LTS) vendors
     - php: 7.3
       env:
-        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel ^5.5 (LTS) vendors
     - php: 7.3
       env:
-        - COMPOSER_FLAGS="" # Cover laravel 7.0.x (LTS) vendors
+        - COMPOSER_FLAGS="" # Cover laravel latest (LTS) vendors
     - php: 7.4
       env:
-        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel ^5.5 (LTS) vendors
     - php: 7.4
       env:
-        - COMPOSER_FLAGS="" # Cover laravel 7.0.x (LTS) vendors
+        - COMPOSER_FLAGS="" # Cover laravel latest (LTS) vendors
     - php: nightly
       env:
-        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel ^5.5 (LTS) vendors
     - php: nightly
       env:
-        - COMPOSER_FLAGS="" # Cover laravel 6.0.x (LTS) vendors
+        - COMPOSER_FLAGS="" # Cover laravel latest (LTS) vendors
   allow_failures:
     - php: 7.4
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+sudo: required
+dist: trusty
+language: php
+
+cache:
+  apt: true
+  directories:
+    - $HOME/.composer/cache
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.1
+      env:
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+    - php: 7.1
+      env:
+        - COMPOSER_FLAGS="" # Cover laravel 7.0.x (LTS) vendors
+    - php: 7.2
+      env:
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+    - php: 7.2
+      env:
+        - COMPOSER_FLAGS="" # Cover laravel 7.0.x (LTS) vendors
+    - php: 7.3
+      env:
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+    - php: 7.3
+      env:
+        - COMPOSER_FLAGS="" # Cover laravel 7.0.x (LTS) vendors
+    - php: 7.4
+      env:
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+    - php: 7.4
+      env:
+        - COMPOSER_FLAGS="" # Cover laravel 7.0.x (LTS) vendors
+    - php: nightly
+      env:
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+    - php: nightly
+      env:
+        - COMPOSER_FLAGS="" # Cover laravel 6.0.x (LTS) vendors
+  allow_failures:
+    - php: 7.4
+    - php: nightly
+
+install:
+  - travis_retry composer install -o --no-interaction --prefer-dist --no-suggest
+  - travis_retry composer update --prefer-source $COMPOSER_FLAGS
+  - composer info illuminate/filesystem | grep "versions"
+
+script: composer test

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^7.1",
         "league/flysystem": "^1.0.40",
         "aws/aws-sdk-php": "^3.0.0",
-        "league/flysystem-aws-s3-v3": "^1.0.15",
+        "league/flysystem-aws-s3-v3": "^1.0.7",
         "illuminate/support": "^5.5|^6.0",
         "illuminate/filesystem": "^5.5|^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         "php": "^7.1",
         "league/flysystem": "^1.0.40",
         "aws/aws-sdk-php": "^3.0.0",
-        "league/flysystem-aws-s3-v3": "^1.0",
-        "illuminate/support": "^5.5 | 6.0",
-        "illuminate/filesystem": "^5.5 | 6.0"
+        "league/flysystem-aws-s3-v3": "^1.0.15",
+        "illuminate/support": "^5.5|^6.0",
+        "illuminate/filesystem": "^5.5|^6.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.10.8"

--- a/composer.json
+++ b/composer.json
@@ -32,14 +32,16 @@
             "fortrabbit\\ObjectStorage\\": "src/"
         }
     },
-    "config": {
-        "bin-dir": "bin"
-    },
     "extra": {
         "laravel": {
             "providers": [
                 "fortrabbit\\ObjectStorage\\ServiceProvider"
             ]
         }
+    },
+    "scripts": {
+        "test": [
+            "vendor/bin/phpstan"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "league/flysystem": "^1.0.40",
         "aws/aws-sdk-php": "^3.0.0",
         "league/flysystem-aws-s3-v3": "^1.0",
-        "illuminate/support": "^5.5 | 6.0",
-        "illuminate/filesystem": "^5.5 | 6.0"
+        "illuminate/support": "^5.5|^6.0",
+        "illuminate/filesystem": "^5.5|^6.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.10.8"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/filesystem": "^5.5|^6.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.10.8"
+        "phpstan/phpstan": "^0.12"
     },
     "autoload": {
         "psr-4": {
@@ -41,7 +41,7 @@
     },
     "scripts": {
         "test": [
-            "vendor/bin/phpstan"
+            "vendor/bin/phpstan analyse src --level 5"
         ]
     }
 }

--- a/src/ObjectStorageAdapter.php
+++ b/src/ObjectStorageAdapter.php
@@ -47,7 +47,7 @@ class ObjectStorageAdapter extends AwsS3Adapter
         try {
             $this->s3Client->execute($command);
         } catch (S3Exception $exception) {
-            return false;
+            return [];
         }
 
         return $this->normalizeResponse($options, $path);


### PR DESCRIPTION
Depends on #3 
Depends on #4 

# Problem

There is no test for this vendor

# Solution

Initialize travis-ci.org tests stack

**This PR request travis-ci.org service activation for the repository.**
- tests stack execution example (on my fork) : [travis-ci pipeline](https://travis-ci.org/github/abenevaut/laravel-object-storage/builds)

## Changelog
### Added
- init travis-ci tests (only phpstan runing) for PHP 7.x
### Changed
- create composer `scripts.test` sub-command to run tests
### Removed
- remove composer `config.bin-dir`, remplaced by composer `scripts.test` to run tests