### PR TITLE
#1 fix: retrieve illuminate vendors at latest revision 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "league/flysystem": "^1.0.40",
         "aws/aws-sdk-php": "^3.0.0",
         "league/flysystem-aws-s3-v3": "^1.0",
-        "illuminate/support": "^5.5 | 6.0",
-        "illuminate/filesystem": "^5.5 | 6.0"
+        "illuminate/support": "^5.5|^6.0",
+        "illuminate/filesystem": "^5.5|^6.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.10.8"


### PR DESCRIPTION
# Problem

On`master` branch, when executing `composer install` (with PHP 7.3), targeting `illumate/*` vendors to v6.0.
It appear the vendor revision is stuck to `v6.0.0` that is not relative to `illumate/*` vendors for latest revision up to 6.

`composer info illuminate/filesystem | grep "versions"` => output `versions : * v6.0.0`

# Solution

With this PR, composer get latest 6 revision for `illumate/*` vendors.

`composer info illuminate/filesystem | grep "versions"` => output `versions : * v6.18.11`

## Changelog
### Changed
- fix illuminate vendor for revision 6