### PR TITLE
#2 fix: update league/flysystem-aws-s3-v3 lowest revision dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^7.1",
         "league/flysystem": "^1.0.40",
         "aws/aws-sdk-php": "^3.0.0",
-        "league/flysystem-aws-s3-v3": "^1.0.15",
+        "league/flysystem-aws-s3-v3": "^1.0.7",
         "illuminate/support": "^5.5|^6.0",
         "illuminate/filesystem": "^5.5|^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         "php": "^7.1",
         "league/flysystem": "^1.0.40",
         "aws/aws-sdk-php": "^3.0.0",
-        "league/flysystem-aws-s3-v3": "^1.0",
-        "illuminate/support": "^5.5 | 6.0",
-        "illuminate/filesystem": "^5.5 | 6.0"
+        "league/flysystem-aws-s3-v3": "^1.0.15",
+        "illuminate/support": "^5.5|^6.0",
+        "illuminate/filesystem": "^5.5|^6.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.10.8"

--- a/src/ObjectStorageAdapter.php
+++ b/src/ObjectStorageAdapter.php
@@ -47,7 +47,7 @@ class ObjectStorageAdapter extends AwsS3Adapter
         try {
             $this->s3Client->execute($command);
         } catch (S3Exception $exception) {
-            return false;
+            return [];
         }
 
         return $this->normalizeResponse($options, $path);


### PR DESCRIPTION
Depends on #3 

# Problem

On `master`, when executing `composer install` then `composer update --prefer-source --prefer-lowest` to get lowest dependencies to test Laravel 5.5 minimal support for this vendor, It appear we can retrieve `league/flysystem-aws-s3-v3` package at revision before 1.0.7.

Before 1.0.7 of `league/flysystem-aws-s3-v3`, the class `League\Flysystem\AwsS3v3\AwsS3Adapter` is working with 3 constructor parameters, that not the way `fortrabbit\ObjectStorage\ObjectStorageAdapter` is working when instance is created in `fortrabbit\ObjectStorage\ServiceProvider@boot` line 34.

When executing `bin/phpstan analyse src --level 5` with `league/flysystem-aws-s3-v3` revision 1.0.6.
Output:

```
------ ---------------------------------------------------------------------------------------------------------- 
  Line   ServiceProvider.php                                                                                       
 ------ ---------------------------------------------------------------------------------------------------------- 
  34     Class fortrabbit\ObjectStorage\ObjectStorageAdapter constructor invoked with 4 parameters, 2-3 required.  
 ------ ---------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 1 error
```

More your get `league/flysystem-aws-s3-v3` lowest revision, more you have phpstan reviews:

When executing `bin/phpstan analyse src --level 5` with `league/flysystem-aws-s3-v3` revision 1.0.0.
Output:

```
------ ----------------------------------------------------------------------- 
  Line   ObjectStorageAdapter.php                                               
 ------ ----------------------------------------------------------------------- 
  40     Call to method getCommand() on an unknown class Aws\S3Client.          
  48     Call to method execute() on an unknown class Aws\S3Client.             
  50     Method fortrabbit\ObjectStorage\ObjectStorageAdapter::upload() should  
         return array but returns false.                                        
 ------ ----------------------------------------------------------------------- 
 ------ ------------------------------------------------------------------------- 
  Line   ServiceProvider.php                                                      
 ------ ------------------------------------------------------------------------- 
  34     Class fortrabbit\ObjectStorage\ObjectStorageAdapter constructor invoked  
         with 4 parameters, 2-3 required.                                         
  34     Parameter #1 $client of class                                            
         fortrabbit\ObjectStorage\ObjectStorageAdapter constructor expects        
         Aws\S3Client, Aws\S3\S3Client given.                                     
 ------ ------------------------------------------------------------------------- 
 [ERROR] Found 5 errors 
```

# Solution

Fix minimal revision for `league/flysystem-aws-s3-v3` at 1.0.7.

# Changelog
## Changed
- fix minimal revision for `league/flysystem-aws-s3-v3` at 1.0.7
- fix `fortrabbit\ObjectStorage\ObjectStorageAdapter@upload` return value, when `S3Exception` happend, to `[]` because the method have return an array.