### PR TITLE
Declare public constant

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fortrabbit/laravel-object-storage",
+    "name": "bmidget/laravel-object-storage",
     "description": "Flysystem adapter for fortrabbit Object Storage",
     "license": "MIT",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "bmidget/laravel-object-storage",
-    "description": "Flysystem adapter for fortrabbit Object Storage",
+    "description": "Clone of Flysystem adapter for fortrabbit Object Storage",
     "license": "MIT",
     "keywords": [
         "flysystem",

--- a/src/ObjectStorageAdapter.php
+++ b/src/ObjectStorageAdapter.php
@@ -42,6 +42,13 @@ class ObjectStorageAdapter extends AwsS3V3Adapter
      */
     private $visibility;
 
+    public const EXTRA_METADATA_FIELDS = [
+        'Metadata',
+        'StorageClass',
+        'ETag',
+        'VersionId',
+    ];
+
     public function __construct(
         S3ClientInterface   $client,
         string              $bucket,


### PR DESCRIPTION
This fixes #8.

The devs who maintain Flysystem have been made aware that they should change this constant to be at least protected in their own code, but until they make that change, this is necessary.